### PR TITLE
Learning about Notification Actions and how to handle them

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,6 +29,14 @@
             android:name="androidx.work.impl.WorkManagerInitializer"
             android:authorities="${applicationId}.workmanager-init"
             tools:node="remove" />
+
+        <receiver
+            android:name=".broadcasts.NotificationBroadcast"
+            android:exported="true">
+            <!--<intent-filter>
+                <action android:name="android.intent.action." />
+            </intent-filter>-->
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/main/java/personal/ianroberts/dailyreminder/broadcasts/NotificationBroadcast.kt
+++ b/app/src/main/java/personal/ianroberts/dailyreminder/broadcasts/NotificationBroadcast.kt
@@ -1,0 +1,49 @@
+package personal.ianroberts.dailyreminder.broadcasts
+
+import android.app.NotificationManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.annotation.CallSuper
+import dagger.hilt.android.AndroidEntryPoint
+import io.reactivex.schedulers.Schedulers
+import personal.ianroberts.dailyreminder.database.NotificationRepo
+import personal.ianroberts.database.entities.NotificationItem
+import javax.inject.Inject
+
+abstract class HiltBroadcastReceiver : BroadcastReceiver() {
+    @CallSuper
+    override fun onReceive(context: Context, intent: Intent) {
+    }
+}
+
+@AndroidEntryPoint
+class NotificationBroadcast : HiltBroadcastReceiver() {
+
+    @Inject
+    lateinit var repo: NotificationRepo
+
+    override fun onReceive(context: Context, intent: Intent) {
+        super.onReceive(context, intent)
+
+        if (intent.action != "mark as read") return
+
+        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        val notifId = intent.extras?.getInt("notificationId")!!
+
+        repo.getNotification(notifId)
+            .subscribeOn(Schedulers.io())
+            .map {
+                it.copy(read = true)
+            }
+            .doOnSuccess {
+                repo.insert(listOf(it as NotificationItem)).subscribe({}, {})
+            }
+            .subscribe({}, {
+                it.printStackTrace()
+            })
+
+        manager.cancel(notifId)
+    }
+}

--- a/app/src/main/java/personal/ianroberts/dailyreminder/database/NotificationRepo.kt
+++ b/app/src/main/java/personal/ianroberts/dailyreminder/database/NotificationRepo.kt
@@ -12,4 +12,6 @@ class NotificationRepo @Inject constructor(private val dao: NotificationDao) : B
     override fun delete(item: List<NotificationItem>) = dao.delete(*item.toTypedArray())
 
     val allNotifications = dao.getAllNotifications()
+
+    fun getNotification(notificationId: Int) = dao.getNotification(notificationId)
 }

--- a/app/src/main/java/personal/ianroberts/dailyreminder/notifications/NotificationFactoryImpl.kt
+++ b/app/src/main/java/personal/ianroberts/dailyreminder/notifications/NotificationFactoryImpl.kt
@@ -9,10 +9,13 @@ import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
+import androidx.core.graphics.drawable.IconCompat
 import androidx.core.graphics.drawable.toBitmap
+import androidx.core.graphics.drawable.toIcon
 import dagger.hilt.android.qualifiers.ApplicationContext
 import personal.ianroberts.dailyreminder.Constants
 import personal.ianroberts.dailyreminder.R
+import personal.ianroberts.dailyreminder.broadcasts.NotificationBroadcast
 import personal.ianroberts.dailyreminder.preferences.PreferenceManager
 import javax.inject.Inject
 
@@ -49,6 +52,14 @@ class NotificationFactoryImpl @Inject constructor(
 
         val bm = ContextCompat.getDrawable(context, R.mipmap.ic_launcher_new)?.toBitmap()
 
+        val actionIntent = Intent(context, NotificationBroadcast::class.java).apply {
+            putExtra("notificationId", lastNotifId)
+            action = "mark as read"
+        }
+
+        val actionPendingIntent =
+            PendingIntent.getBroadcast(context, 0, actionIntent, PendingIntent.FLAG_UPDATE_CURRENT)
+
         val builder = NotificationCompat.Builder(context, channel)
             .setSmallIcon(R.mipmap.ic_launcher_new)
             .setLargeIcon(bm)
@@ -60,7 +71,11 @@ class NotificationFactoryImpl @Inject constructor(
                     .bigText(preview)
             )
             .addAction(
-                NotificationCompat.Action(null, context.getString(R.string.mark_as_read), null)
+                NotificationCompat.Action(
+                    IconCompat.createFromIcon(context, bm?.toIcon()!!),
+                    context.getString(R.string.mark_as_read),
+                    actionPendingIntent
+                )
             )
             .setPriority(NotificationCompat.PRIORITY_HIGH)
 

--- a/app/src/main/java/personal/ianroberts/dailyreminder/notifications/NotificationItemDiff.kt
+++ b/app/src/main/java/personal/ianroberts/dailyreminder/notifications/NotificationItemDiff.kt
@@ -10,6 +10,6 @@ class NotificationItemDiff : DiffUtil.ItemCallback<NotificationItem>() {
     }
 
     override fun areContentsTheSame(oldItem: NotificationItem, newItem: NotificationItem): Boolean {
-        return oldItem.id == newItem.id && oldItem.content == newItem.content && oldItem.read == newItem.read
+        return oldItem == newItem
     }
 }

--- a/app/src/main/java/personal/ianroberts/dailyreminder/notifications/NotificationListFragment.kt
+++ b/app/src/main/java/personal/ianroberts/dailyreminder/notifications/NotificationListFragment.kt
@@ -1,7 +1,6 @@
 package personal.ianroberts.dailyreminder.notifications
 
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -40,9 +39,12 @@ class NotificationListFragment : Fragment() {
         recyclerView.addItemDecoration(dividerItemDecoration)
 
         vm.notifications.observe(viewLifecycleOwner, Observer {
-            Log.i("IanRoberts", "${it.size}")
-            adapter.updateData(it, {})
-            adapter.notifyDataSetChanged()
+            val sizeChanged = adapter.itemCount != it.size
+            adapter.updateData(it) {
+                adapter.notifyDataSetChanged()
+
+                if (sizeChanged) recyclerView.smoothScrollToPosition(0)
+            }
         })
     }
 }

--- a/app/src/main/java/personal/ianroberts/dailyreminder/notifications/NotificationListViewModel.kt
+++ b/app/src/main/java/personal/ianroberts/dailyreminder/notifications/NotificationListViewModel.kt
@@ -28,6 +28,9 @@ class NotificationListViewModel @ViewModelInject constructor(
             notificationRepo
                 .allNotifications
                 .subscribeOn(Schedulers.io())
+                .map {
+                    it.sortedByDescending { it.id }
+                }
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(_notifications::postValue, {})
         )

--- a/app/src/main/java/personal/ianroberts/dailyreminder/workers/ReminderWorker.kt
+++ b/app/src/main/java/personal/ianroberts/dailyreminder/workers/ReminderWorker.kt
@@ -65,7 +65,16 @@ class ReminderWorker @WorkerInject constructor(
             )
         }
 
-        return notificationRepo.insert(listOf(NotificationItem(lastNotifId + 1L, System.currentTimeMillis(), nextReminder)))
+        return notificationRepo.insert(
+            listOf(
+                NotificationItem(
+                    lastNotifId + 1L,
+                    System.currentTimeMillis(),
+                    nextReminder,
+                    notificationId = if (silent) 0 else lastNotifId + 1
+                )
+            )
+        )
             .subscribeOn(backgroundScheduler)
             .materialize<Unit>()
             .map {

--- a/app/src/main/res/layout/row_notification.xml
+++ b/app/src/main/res/layout/row_notification.xml
@@ -25,12 +25,21 @@
             tools:text="time" />
 
         <TextView
+            android:id="@+id/notification_content"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@{item.content}"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/timestamp"
             tools:text="content" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@{String.valueOf(item.read)}"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/notification_content"
+            tools:text="read" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/database/src/main/java/personal/ianroberts/database/dao/NotificationDao.kt
+++ b/database/src/main/java/personal/ianroberts/database/dao/NotificationDao.kt
@@ -3,6 +3,7 @@ package personal.ianroberts.database.dao
 import androidx.room.Dao
 import androidx.room.Query
 import io.reactivex.Flowable
+import io.reactivex.Maybe
 import personal.ianroberts.database.entities.NotificationItem
 
 @Dao
@@ -10,4 +11,7 @@ abstract class NotificationDao : BaseDao<NotificationItem> {
 
     @Query("SELECT * FROM notification")
     abstract fun getAllNotifications(): Flowable<List<NotificationItem>>
+
+    @Query("SELECT * FROM notification where notificationId = :notificationId LIMIT 1")
+    abstract fun getNotification(notificationId: Int): Maybe<NotificationItem>
 }

--- a/database/src/main/java/personal/ianroberts/database/entities/NotificationItem.kt
+++ b/database/src/main/java/personal/ianroberts/database/entities/NotificationItem.kt
@@ -8,5 +8,6 @@ data class NotificationItem(
     @PrimaryKey(autoGenerate = false) val id: Long,
     val time: Long,
     val content: String,
-    val read: Boolean = false
+    val read: Boolean = false,
+    val notificationId: Int
 )


### PR DESCRIPTION
TIL - @AndroidEntryPoint is bugged from broadcastreceiver and also today I learn about notification actions.

Achieved:
Mark As Read action links the notificationId to the db id and marks the specific notification (shown on system ui) as read
Decided to reverse the list because I didn't want to scroll down so much, so new notifications are at the top